### PR TITLE
🔧 Fix ESLint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-
+  "recommendations": ["dbaeumer.vscode-eslint"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,7 @@
 {
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true,
+    "source.fixAll.eslint": true,
+    "source.organizeImports": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "vite"
+    "start": "vite",
+    "eslint": "eslint --fix ."
   },
   "keywords": [],
   "author": "",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
+// eslint-disable-next-line no-undef
 module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
-    
   },
 }


### PR DESCRIPTION
ESLint integration with VSCode was missing. With this, auto-fixable ESLint errors can be fixed on save, saving some time on debugging potential errors.

Additionally, you'll be able to run `prettier eslint` to get a list of ESLint violations in the project and auto-fix the easiest ones.